### PR TITLE
feat: signup account

### DIFF
--- a/src/components/SignUpAccount.svelte
+++ b/src/components/SignUpAccount.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Button from './base/Button.svelte'
+  import Input from './base/Input.svelte'
+
+  export let email: string
+
+  let document: string
+  let password: string
+
+  function canSignUp(email: string, document: string, password: string): boolean {
+    return Boolean(email && document && password)
+  }
+
+  $: shouldDisableButton = !canSignUp(email, document, password)
+</script>
+
+<Input label="email" bind:value={email} />
+
+<Input label="document" bind:value={document} />
+
+<Input label="password" bind:value={password} />
+
+<Button disabled={shouldDisableButton}>Create account</Button>

--- a/src/components/base/Input.svelte
+++ b/src/components/base/Input.svelte
@@ -1,14 +1,16 @@
-<script>
+<script lang="ts">
   export let label = ''
   export let value = ''
+
+  const inputId = `input-${label}`
 </script>
 
 <div class="input-container">
-  <label for="input">
+  <label for={inputId}>
     { label }
   </label>
   <input
-    id="input"
+    id={inputId}
     class="input"
     type="text"
     bind:value

--- a/src/components/tests/SignUpAccount.test.ts
+++ b/src/components/tests/SignUpAccount.test.ts
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/svelte'
+import userEvent from '@testing-library/user-event'
+import { test } from 'vitest'
+
+import SignUpAccount from '../SignUpAccount.svelte'
+
+describe('SignUpAccount.svelte', () => {
+  test('button must be disabled when all required data is empty', () => {
+    render(SignUpAccount, { email: 'test@test.com' })
+
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveProperty('disabled', true)
+  })
+
+  test('button must be disabled when at least one required account field is empty', async () => {
+    const user = userEvent.setup()
+
+    render(SignUpAccount, { email: 'test@test.com' })
+
+    const documentInput = await screen.findByLabelText('document')
+    await user.type(documentInput, '123456789')
+
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveProperty('disabled', true)
+  })
+
+  test('button must be disabled when the provided email is removed and not typed again', async () => {
+    const user = userEvent.setup()
+
+    render(SignUpAccount, { email: 'test@test.com' })
+
+    const emailInput = await screen.findByLabelText('email')
+    await user.clear(emailInput)
+
+    const documentInput = await screen.findByLabelText('document')
+    await user.type(documentInput, '123456789')
+
+    const passwordInput = await screen.findByLabelText('password')
+    await user.type(passwordInput, '123456')
+
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveProperty('disabled', true)
+  })
+
+  test('button must be enabled when all required account fields are filled', async () => {
+    const user = userEvent.setup()
+
+    render(SignUpAccount, { email: 'test@test.com' })
+
+    const documentInput = screen.getByLabelText('document')
+    await user.type(documentInput, '123456789')
+
+    const passwordInput = screen.getByLabelText('password')
+    await user.type(passwordInput, '123456')
+
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveProperty('disabled', false)
+  })
+})


### PR DESCRIPTION
Sets the input id correctly using the label as the unique key.

Creates the sign up account component to allow the creation of a new account.